### PR TITLE
Fix typos in help messages of argument out_file / Add .pkl to generated embedding file names

### DIFF
--- a/dense_retriever.py
+++ b/dense_retriever.py
@@ -282,7 +282,7 @@ if __name__ == '__main__':
     parser.add_argument('--encoded_ctx_file', type=str, default=None,
                         help='Glob path to encoded passages (from generate_dense_embeddings tool)')
     parser.add_argument('--out_file', type=str, default=None,
-                        help='output .tsv file path to write results to ')
+                        help='output .json file path to write results to ')
     parser.add_argument('--match', type=str, default='string', choices=['regex', 'string'],
                         help="Answer matching logic type")
     parser.add_argument('--n-docs', type=int, default=200, help="Amount of top docs to return")

--- a/generate_dense_embeddings.py
+++ b/generate_dense_embeddings.py
@@ -130,7 +130,7 @@ if __name__ == '__main__':
 
     parser.add_argument('--ctx_file', type=str, default=None, help='Path to passages set .tsv file')
     parser.add_argument('--out_file', required=True, type=str, default=None,
-                        help='output .tsv file path to write results to ')
+                        help='output file path to write results to')
     parser.add_argument('--shard_id', type=int, default=0, help="Number(0-based) of data shard to process")
     parser.add_argument('--num_shards', type=int, default=1, help="Total amount of data shards")
     parser.add_argument('--batch_size', type=int, default=32, help="Batch size for the passage encoder forward pass")

--- a/generate_dense_embeddings.py
+++ b/generate_dense_embeddings.py
@@ -112,7 +112,7 @@ def main(args):
 
     data = gen_ctx_vectors(rows, encoder, tensorizer, True)
 
-    file = args.out_file + '_' + str(args.shard_id)
+    file = args.out_file + '_' + str(args.shard_id) + '.pkl'
     pathlib.Path(os.path.dirname(file)).mkdir(parents=True, exist_ok=True)
     logger.info('Writing results to %s' % file)
     with open(file, mode='wb') as f:


### PR DESCRIPTION
- Argument `out_file` of `dense_retriever.py` is described as a TSV file but is in fact a JSON file. Therefore, I changed .tsv to .json in the help message.
- Argument `out_file` of `generate_dense_embeddings.py` is described as a TSV file but is in fact the prefix of pickle files. Therefore, I removed .tsv from the help message.
- The embedding files downloaded from `data/download_data.py` are named as `{file_name}_{shard_id}.pkl`, but `generate_dense_embeddings.py` does not save the files with .pkl extension. Therefore, I added .pkl at the end of the names of the dumped embedding files.