### PR TITLE
Fix typos in method call and help messages / Add .pkl to generated embedding file names / Reduce memory usage

### DIFF
--- a/dense_retriever.py
+++ b/dense_retriever.py
@@ -282,7 +282,7 @@ if __name__ == '__main__':
     parser.add_argument('--encoded_ctx_file', type=str, default=None,
                         help='Glob path to encoded passages (from generate_dense_embeddings tool)')
     parser.add_argument('--out_file', type=str, default=None,
-                        help='output .tsv file path to write results to ')
+                        help='output .json file path to write results to ')
     parser.add_argument('--match', type=str, default='string', choices=['regex', 'string'],
                         help="Answer matching logic type")
     parser.add_argument('--n-docs', type=int, default=200, help="Amount of top docs to return")

--- a/dense_retriever.py
+++ b/dense_retriever.py
@@ -222,10 +222,10 @@ def main(args):
 
     index_buffer_sz = args.index_buffer
     if args.hnsw_index:
-        index = DenseHNSWFlatIndexer(vector_size)
         index_buffer_sz = -1  # encode all at once
+        index = DenseHNSWFlatIndexer(vector_size, index_buffer_sz)
     else:
-        index = DenseFlatIndexer(vector_size)
+        index = DenseFlatIndexer(vector_size, index_buffer_sz)
 
     retriever = DenseRetriever(encoder, args.batch_size, tensorizer, index)
 

--- a/dense_retriever.py
+++ b/dense_retriever.py
@@ -81,23 +81,6 @@ class DenseRetriever(object):
         assert query_tensor.size(0) == len(questions)
         return query_tensor
 
-    def index_encoded_data(self, vector_files: List[str], buffer_size: int = 50000):
-        """
-        Indexes encoded passages takes form a list of files
-        :param vector_files: file names to get passages vectors from
-        :param buffer_size: size of a buffer (amount of passages) to send for the indexing at once
-        :return:
-        """
-        buffer = []
-        for i, item in enumerate(iterate_encoded_files(vector_files)):
-            db_id, doc_vector = item
-            buffer.append((db_id, doc_vector))
-            if 0 < buffer_size == len(buffer):
-                self.index.index_data(buffer)
-                buffer = []
-        self.index.index_data(buffer)
-        logger.info('Data indexing completed.')
-
     def get_top_docs(self, query_vectors: np.array, top_docs: int = 100) -> List[Tuple[List[object], List[float]]]:
         """
         Does the retrieval of the best matching passages given the query vectors batch
@@ -220,12 +203,10 @@ def main(args):
     vector_size = model_to_load.get_out_size()
     logger.info('Encoder vector_size=%d', vector_size)
 
-    index_buffer_sz = args.index_buffer
     if args.hnsw_index:
-        index_buffer_sz = -1  # encode all at once
-        index = DenseHNSWFlatIndexer(vector_size, index_buffer_sz)
+        index = DenseHNSWFlatIndexer(vector_size, args.index_buffer)
     else:
-        index = DenseFlatIndexer(vector_size, index_buffer_sz)
+        index = DenseFlatIndexer(vector_size, args.index_buffer)
 
     retriever = DenseRetriever(encoder, args.batch_size, tensorizer, index)
 
@@ -235,11 +216,11 @@ def main(args):
     input_paths = glob.glob(ctx_files_pattern)
 
     index_path = "_".join(input_paths[0].split("_")[:-1])
-    if args.save_or_load_index and os.path.exists(index_path):
+    if args.save_or_load_index and (os.path.exists(index_path) or os.path.exists(index_path + ".index.dpr")):
         retriever.index.deserialize_from(index_path)
     else:
         logger.info('Reading all passages data from files: %s', input_paths)
-        retriever.index_encoded_data(input_paths, buffer_size=index_buffer_sz)
+        retriever.index.index_data(input_paths)
         if args.save_or_load_index:
             retriever.index.serialize(index_path)
     # get questions & answers

--- a/dense_retriever.py
+++ b/dense_retriever.py
@@ -236,7 +236,7 @@ def main(args):
 
     index_path = "_".join(input_paths[0].split("_")[:-1])
     if args.save_or_load_index and os.path.exists(index_path):
-        retriever.index.deserialize(index_path)
+        retriever.index.deserialize_from(index_path)
     else:
         logger.info('Reading all passages data from files: %s', input_paths)
         retriever.index_encoded_data(input_paths, buffer_size=index_buffer_sz)

--- a/dpr/indexer/faiss_indexers.py
+++ b/dpr/indexer/faiss_indexers.py
@@ -10,9 +10,10 @@
 """
 
 import os
+import time
 import logging
 import pickle
-from typing import List, Tuple
+from typing import List, Tuple, Iterator
 
 import faiss
 import numpy as np
@@ -27,7 +28,25 @@ class DenseIndexer(object):
         self.index_id_to_db_id = []
         self.index = None
 
-    def index_data(self, data: List[Tuple[object, np.array]]):
+    def index_data(self, vector_files: List[str]):
+        start_time = time.time()
+        buffer = []
+        for i, item in enumerate(iterate_encoded_files(vector_files)):
+            db_id, doc_vector = item
+            buffer.append((db_id, doc_vector))
+            if 0 < self.buffer_size == len(buffer):
+                # indexing in batches is beneficial for many faiss index types
+                self._index_batch(buffer)
+                logger.info('data indexed %d, used_time: %f sec.',
+                            len(self.index_id_to_db_id), time.time() - start_time)
+                buffer = []
+        self._index_batch(buffer)
+
+        indexed_cnt = len(self.index_id_to_db_id)
+        logger.info('Total data indexed %d', indexed_cnt)
+        logger.info('Data indexing completed.')
+
+    def _index_batch(self, data: List[Tuple[object, np.array]]):
         raise NotImplementedError
 
     def search_knn(self, query_vectors: np.array, top_docs: int) -> List[Tuple[List[object], List[float]]]:
@@ -75,18 +94,15 @@ class DenseFlatIndexer(DenseIndexer):
         super(DenseFlatIndexer, self).__init__(buffer_size=buffer_size)
         self.index = faiss.IndexFlatIP(vector_sz)
 
-    def index_data(self, data: List[Tuple[object, np.array]]):
-        n = len(data)
-        # indexing in batches is beneficial for many faiss index types
-        for i in range(0, n, self.buffer_size):
-            db_ids = [t[0] for t in data[i:i + self.buffer_size]]
-            vectors = [np.reshape(t[1], (1, -1)) for t in data[i:i + self.buffer_size]]
-            vectors = np.concatenate(vectors, axis=0)
-            self._update_id_mapping(db_ids)
-            self.index.add(vectors)
+    def index_data(self, vector_files: List[str]):
+        super(DenseFlatIndexer, self).index_data(vector_files)
 
-        indexed_cnt = len(self.index_id_to_db_id)
-        logger.info('Total data indexed %d', indexed_cnt)
+    def _index_batch(self, data: List[Tuple[object, np.array]]):
+        db_ids = [t[0] for t in data]
+        vectors = [np.reshape(t[1], (1, -1)) for t in data]
+        vectors = np.concatenate(vectors, axis=0)
+        self._update_id_mapping(db_ids)
+        self.index.add(vectors)
 
     def search_knn(self, query_vectors: np.array, top_docs: int) -> List[Tuple[List[object], List[float]]]:
         scores, indexes = self.index.search(query_vectors, top_docs)
@@ -111,40 +127,45 @@ class DenseHNSWFlatIndexer(DenseIndexer):
         index.hnsw.efSearch = ef_search
         index.hnsw.efConstruction = ef_construction
         self.index = index
-        self.phi = 0
+        self.phi = None
 
-    def index_data(self, data: List[Tuple[object, np.array]]):
-        n = len(data)
+    def index_data(self, vector_files: List[str]):
+        self._set_phi(vector_files)
 
-        # max norm is required before putting all vectors in the index to convert inner product similarity to L2
-        if self.phi > 0:
-            raise RuntimeError('DPR HNSWF index needs to index all data at once,'
-                               'results will be unpredictable otherwise.')
+        super(DenseHNSWFlatIndexer, self).index_data(vector_files)
+
+    def _set_phi(self, vector_files: List[str]):
+        """
+        Calculates the max norm from the whole data and assign it to self.phi: necessary to transform IP -> L2 space
+        :param vector_files: file names to get passages vectors from
+        :return:
+        """
         phi = 0
-        for i, item in enumerate(data):
+        for i, item in enumerate(iterate_encoded_files(vector_files)):
             id, doc_vector = item
             norms = (doc_vector ** 2).sum()
             phi = max(phi, norms)
         logger.info('HNSWF DotProduct -> L2 space phi={}'.format(phi))
-        self.phi = 0
+        self.phi = phi
 
-        # indexing in batches is beneficial for many faiss index types
-        for i in range(0, n, self.buffer_size):
-            db_ids = [t[0] for t in data[i:i + self.buffer_size]]
-            vectors = [np.reshape(t[1], (1, -1)) for t in data[i:i + self.buffer_size]]
+    def _index_batch(self, data: List[Tuple[object, np.array]]):
+        # max norm is required before putting all vectors in the index to convert inner product similarity to L2
+        if self.phi is None:
+            raise RuntimeError('Max norm needs to be calculated from all data at once,'
+                               'results will be unpredictable otherwise.'
+                               'run `set_phi()` before calling this method.')
 
-            norms = [(doc_vector ** 2).sum() for doc_vector in vectors]
-            aux_dims = [np.sqrt(phi - norm) for norm in norms]
-            hnsw_vectors = [np.hstack((doc_vector, aux_dims[i].reshape(-1, 1))) for i, doc_vector in
-                            enumerate(vectors)]
-            hnsw_vectors = np.concatenate(hnsw_vectors, axis=0)
+        db_ids = [t[0] for t in data]
+        vectors = [np.reshape(t[1], (1, -1)) for t in data]
 
-            self._update_id_mapping(db_ids)
-            self.index.add(hnsw_vectors)
-            logger.info('data indexed %d', len(self.index_id_to_db_id))
+        norms = [(doc_vector ** 2).sum() for doc_vector in vectors]
+        aux_dims = [np.sqrt(self.phi - norm) for norm in norms]
+        hnsw_vectors = [np.hstack((doc_vector, aux_dims[i].reshape(-1, 1))) for i, doc_vector in
+                        enumerate(vectors)]
+        hnsw_vectors = np.concatenate(hnsw_vectors, axis=0)
 
-        indexed_cnt = len(self.index_id_to_db_id)
-        logger.info('Total data indexed %d', indexed_cnt)
+        self._update_id_mapping(db_ids)
+        self.index.add(hnsw_vectors)
 
     def search_knn(self, query_vectors: np.array, top_docs: int) -> List[Tuple[List[object], List[float]]]:
 
@@ -161,3 +182,13 @@ class DenseHNSWFlatIndexer(DenseIndexer):
         super(DenseHNSWFlatIndexer, self).deserialize_from(file)
         # to trigger warning on subsequent indexing
         self.phi = 1
+
+
+def iterate_encoded_files(vector_files: list) -> Iterator[Tuple[object, np.array]]:
+    for i, file in enumerate(vector_files):
+        logger.info('Reading file %s', file)
+        with open(file, "rb") as reader:
+            doc_vectors = pickle.load(reader)
+            for doc in doc_vectors:
+                db_id, doc_vector = doc
+                yield db_id, doc_vector

--- a/dpr/indexer/faiss_indexers.py
+++ b/dpr/indexer/faiss_indexers.py
@@ -178,7 +178,7 @@ class DenseHNSWFlatIndexer(DenseIndexer):
     def deserialize_from(self, file: str):
         super(DenseHNSWFlatIndexer, self).deserialize_from(file)
         # to trigger warning on subsequent indexing
-        self.phi = 1
+        self.phi = None
 
 
 def iterate_encoded_files(vector_files: list) -> Iterator[Tuple[object, np.array]]:

--- a/dpr/indexer/faiss_indexers.py
+++ b/dpr/indexer/faiss_indexers.py
@@ -94,9 +94,6 @@ class DenseFlatIndexer(DenseIndexer):
         super(DenseFlatIndexer, self).__init__(buffer_size=buffer_size)
         self.index = faiss.IndexFlatIP(vector_sz)
 
-    def index_data(self, vector_files: List[str]):
-        super(DenseFlatIndexer, self).index_data(vector_files)
-
     def _index_batch(self, data: List[Tuple[object, np.array]]):
         db_ids = [t[0] for t in data]
         vectors = [np.reshape(t[1], (1, -1)) for t in data]

--- a/dpr/indexer/faiss_indexers.py
+++ b/dpr/indexer/faiss_indexers.py
@@ -150,7 +150,7 @@ class DenseHNSWFlatIndexer(DenseIndexer):
         if self.phi is None:
             raise RuntimeError('Max norm needs to be calculated from all data at once,'
                                'results will be unpredictable otherwise.'
-                               'run `set_phi()` before calling this method.')
+                               'Run `_set_phi()` before calling this method.')
 
         db_ids = [t[0] for t in data]
         vectors = [np.reshape(t[1], (1, -1)) for t in data]

--- a/dpr/models/biencoder.py
+++ b/dpr/models/biencoder.py
@@ -165,10 +165,10 @@ class BiEncoder(nn.Module):
 class BiEncoderNllLoss(object):
 
     def calc(self, q_vectors: T, ctx_vectors: T, positive_idx_per_question: list,
-             hard_negatice_idx_per_question: list = None) -> Tuple[T, int]:
+             hard_negative_idx_per_question: list = None) -> Tuple[T, int]:
         """
         Computes nll loss for the given lists of question and ctx vectors.
-        Note that although hard_negatice_idx_per_question in not currently in use, one can use it for the
+        Note that although hard_negative_idx_per_question in not currently in use, one can use it for the
         loss modifications. For example - weighted NLL with different factors for hard vs regular negatives.
         :return: a tuple of loss value and amount of correct predictions per batch
         """

--- a/generate_dense_embeddings.py
+++ b/generate_dense_embeddings.py
@@ -130,7 +130,7 @@ if __name__ == '__main__':
 
     parser.add_argument('--ctx_file', type=str, default=None, help='Path to passages set .tsv file')
     parser.add_argument('--out_file', required=True, type=str, default=None,
-                        help='output .tsv file path to write results to ')
+                        help='output file path to write results to')
     parser.add_argument('--shard_id', type=int, default=0, help="Number(0-based) of data shard to process")
     parser.add_argument('--num_shards', type=int, default=1, help="Total amount of data shards")
     parser.add_argument('--batch_size', type=int, default=32, help="Batch size for the passage encoder forward pass")

--- a/generate_dense_embeddings.py
+++ b/generate_dense_embeddings.py
@@ -112,7 +112,7 @@ def main(args):
 
     data = gen_ctx_vectors(rows, encoder, tensorizer, True)
 
-    file = args.out_file + '_' + str(args.shard_id)
+    file = args.out_file + '_' + str(args.shard_id) + '.pkl'
     pathlib.Path(os.path.dirname(file)).mkdir(parents=True, exist_ok=True)
     logger.info('Writing results to %s' % file)
     with open(file, mode='wb') as f:


### PR DESCRIPTION
- Argument `out_file` of `dense_retriever.py` is described as a TSV file but is in fact a JSON file. Therefore, I changed .tsv to .json in the help message.
- Argument `out_file` of `generate_dense_embeddings.py` is described as a TSV file but is in fact the prefix of pickle files. Therefore, I removed .tsv from the help message.
- The embedding files downloaded from `data/download_data.py` are named as `{out_file}_{shard_id}.pkl`, but `generate_dense_embeddings.py` does not save the files with .pkl extension. Therefore, I added .pkl at the end of the names of the dumped embedding files.
- L239 of `dense_retriever.py` calls `deserialize` method, which looks like a typo. Therefore, I changed it to `deserialize_from`.
- `index_buffer_sz` is not passed to the constructor of Indexers, thus I fixed that part.
- dense_retriever.py memory usage enhancement (#43)