### PR TITLE
Fixed package discovery in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 with open('README.md') as f:
     readme = f.read()
@@ -23,6 +23,7 @@ setup(
     ],
     long_description=readme,
     long_description_content_type='text/markdown',
+    packages=find_packages(),
     setup_requires=[
         'setuptools>=18.0',
     ],


### PR DESCRIPTION
This fixes a simple bug in `setup.py`

Currently, running the following:
```
 mkvirtualenv test_dpr_setup; pip install git+ssh://git@github.com/facebookresearch/DPR#egg=dpr; python -c "from dpr.models import biencoder"
```
fails with 
```
ModuleNotFoundError: No module named 'dpr'
```

While there is a work-around - installing with `-e`  - as editable, it is not ideal. It is also impossible (?) to specify this in `install_requires` of another package.

The PR fixes this, which can be tested by running
```
mkvirtualenv test_dpr_setup_fixed; pip install git+ssh://git@github.com/tomaszpietruszka-globality/DPR@fix_package_setup#egg=dpr; python -c "from dpr.models import biencoder"
```