### PR TITLE
change pad_token_type_id to pad_token_id

### DIFF
--- a/dpr/models/hf_models.py
+++ b/dpr/models/hf_models.py
@@ -166,7 +166,7 @@ class BertTensorizer(Tensorizer):
         return torch.tensor([self.tokenizer.sep_token_id])
 
     def get_pad_id(self) -> int:
-        return self.tokenizer.pad_token_type_id
+        return self.tokenizer.pad_token_id
 
     def get_attn_mask(self, tokens_tensor: T) -> T:
         return tokens_tensor != self.get_pad_id()


### PR DESCRIPTION
For BertTokenizer, pad_token_id and pad_token_type_id are both 0.
For RobertaTokenizer, pad_token_id is 0, pad_token_type_id is 1.