### PR TITLE
fix: error fixed in gradient_acc_step

### DIFF
--- a/train_extractive_reader.py
+++ b/train_extractive_reader.py
@@ -551,7 +551,7 @@ class ReaderTrainer(object):
         if cfg.n_gpu > 1:
             loss = loss.mean()
         if cfg.train.gradient_accumulation_steps > 1:
-            loss = loss / cfg.trani.gradient_accumulation_steps
+            loss = loss / cfg.train.gradient_accumulation_steps
 
         return loss
 


### PR DESCRIPTION
An error occurred due to the typo when `gradient_accumulation_steps` is greater than 1.
(`train` <- `trani`)