### PR TITLE
Fix: incorrect reference for gradient_acc_steps.

### DIFF
--- a/train_dense_encoder.py
+++ b/train_dense_encoder.py
@@ -729,7 +729,7 @@ def _do_biencoder_fwd_pass(
     if cfg.n_gpu > 1:
         loss = loss.mean()
     if cfg.train.gradient_accumulation_steps > 1:
-        loss = loss / cfg.gradient_accumulation_steps
+        loss = loss / cfg.train.gradient_accumulation_steps
     return loss, is_correct
 
 


### PR DESCRIPTION
According to the example, it seems that `gradient_accumulation_steps` should refer to the configuration in `conf/train/`, instead of `conf/biencoder_train_cfg.yaml`.