### PR TITLE
Fix `pip install .` by adding empty py_modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     ],
     long_description=readme,
     long_description_content_type="text/markdown",
+    py_modules=[],
     setup_requires=[
         "setuptools>=18.0",
     ],


### PR DESCRIPTION
This fixes the following step:

```
cd DPR/
pip install .
```

This issue was originally reported in: https://github.com/facebookresearch/DPR/issues/223

@AkariAsai proposed the following fix: https://github.com/facebookresearch/DPR/issues/223#issuecomment-1192218375

This PR simply implements the proposed fix as is, and it successfully corrects the reported error