### PR TITLE
Explicitly added     py_modules in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
     ],
-    py_modules=[],
+    py_modules=["dpr"],
     long_description=readme,
     long_description_content_type="text/markdown",
     setup_requires=[

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
     ],
+    py_modules=[],
     long_description=readme,
     long_description_content_type="text/markdown",
     setup_requires=[


### PR DESCRIPTION
some versions of pip throw an error when because of a missing py_modules config in the setup.py.  Setting this allows for installation using, e.g. pip install -r requirements with pip 22