### PR TITLE
Make module installable using pip, even from GH

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 with open("README.md") as f:
     readme = f.read()
@@ -21,7 +21,8 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
     ],
-    py_modules=["dpr"],
+    py_modules=[''],
+    packages=find_packages(),
     long_description=readme,
     long_description_content_type="text/markdown",
     setup_requires=[

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
     ],
-    py_modules=[],
+    py_modules=["dpr"],
     long_description=readme,
     long_description_content_type="text/markdown",
     setup_requires=[

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
     ],
+    py_modules=[],
     long_description=readme,
     long_description_content_type="text/markdown",
     setup_requires=[


### PR DESCRIPTION
Modified the setup.py file to make the pip install work. It can now be installed directly from github using pip.
