### PR TITLE
setup.py error during installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 with open("README.md") as f:
     readme = f.read()
@@ -26,6 +26,7 @@ setup(
     setup_requires=[
         "setuptools>=18.0",
     ],
+    packages=find_packages(exclude=["conf"]),
     install_requires=[
         "faiss-cpu>=1.6.1",
         "filelock",


### PR DESCRIPTION
There's some erorr during installing dependency with setup.py, like below. 

![image](https://user-images.githubusercontent.com/11407756/230306212-c2d2bf86-6c14-4b61-b95b-510bdc7acbfd.png)

This could be solved by simply adding an exclude statement.